### PR TITLE
Correct how CocoaPods is written in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ RGB color value to the UIColor conversion kit.
 ## Installation
 - Import the main header file：`#import "RRGB.h"`
 
-## cocoapods 
+## CocoaPods 
 `  pod 'RGB' `
 
 ## Use 


### PR DESCRIPTION
See https://github.com/CocoaPods/shared_resources/tree/master/media :)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
